### PR TITLE
Fixed float and blinking scroll bar for results page

### DIFF
--- a/resultPage.css
+++ b/resultPage.css
@@ -111,19 +111,12 @@ section.food-section h1 span {
   animation-duration: 2900ms;
   animation-iteration-count: infinite;
   transition-timing-function: ease;
-  transition: 500ms;
 }
 
 @keyframes blink {
   0% {opacity: 0;}
   50% {opacity: .2;}
   100% {opacity: 0}
-}
-
-.hideBlinkScrollBar {
-  height: 0;
-  font-size: 0;
-  top: 120vh;
 }
 
 .modal {
@@ -147,6 +140,7 @@ section.how-to {
   justify-content: space-evenly;
   align-items: center;
   flex-direction: column;
+  clear: both;
 }
 
 section.how-to h1 {

--- a/resultsPage.js
+++ b/resultsPage.js
@@ -209,5 +209,5 @@ function handleInputBarEnterKey(event){
 }
 
 function hideBlinkScrollBar () {
-  $('.blinkScrollBar').addClass('hideBlinkScrollBar');
+  $('.blinkScrollBar').css('display', 'none');
 }


### PR DESCRIPTION
Added clear:both to how-to section to keep the paragraph above from changing it.
Changed animatino on scroll bar so it disappears on scroll rather than animates out. Deleted CSS for the animate out.